### PR TITLE
Text Filter: Expose new customization options to users

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -2047,6 +2047,7 @@ ImGuiTextFilter::ImGuiTextFilter(const char* default_filter)
     : MatchMode(ImGuiTextFilterMode_Or)
     , WordSplitter(',')
     , MinWordSize(0)
+    , ShowSettings(false)
 {
     if (default_filter)
     {
@@ -2061,11 +2062,36 @@ ImGuiTextFilter::ImGuiTextFilter(const char* default_filter)
 
 bool ImGuiTextFilter::Draw(const char* label, float width)
 {
+    ImGui::PushID(this);
+    const ImGuiDir ArrowDirection = ShowSettings ? ImGuiDir_Down : ImGuiDir_Right;
+    if (ImGui::ArrowButton("Settings", ArrowDirection))
+        ShowSettings = !ShowSettings;
+    if (ImGui::IsItemHovered())
+        ImGui::SetTooltip("Filter settings");
+    ImGui::PopID();
+
+    ImGui::SameLine();
+
     if (width != 0.0f)
         ImGui::SetNextItemWidth(width);
     bool value_changed = ImGui::InputText(label, InputBuf, IM_ARRAYSIZE(InputBuf));
     if (value_changed)
         Build();
+
+    if (ShowSettings)
+    {
+        ImGui::TreePush(this);
+        const char *modes[] = {"Or", "And"};
+        ImGui::Combo("Match mode", &MatchMode, modes, 2);
+
+        char buff[2] = {WordSplitter, 0};
+        ImGui::InputText("Word splitter", buff, sizeof(buff));
+        WordSplitter = buff[0];
+
+        ImGui::InputScalar("Min word size", ImGuiDataType_S8, &MinWordSize);
+        ImGui::TreePop();
+    }
+
     return value_changed;
 }
 

--- a/imgui.h
+++ b/imgui.h
@@ -1713,6 +1713,7 @@ struct ImGuiTextFilter
     char                InputBuf[256];
     ImVector<ImGuiTextRange> Filters;
     int                 NegativeFilterCount;
+    bool                ShowSettings;
 
     // [Configuration]
     ImGuiTextFilterMode MatchMode;      // if true then all words must match, otherwise any matching word will be a pass


### PR DESCRIPTION
Added a toggle on the left of the filter input that expands to expose the new customization options to users like so:

* Collapsed:
![image](https://user-images.githubusercontent.com/7548697/193059880-bd0da791-334d-4f72-af1b-ac5a0b52627b.png)

* Expanded:
![image](https://user-images.githubusercontent.com/7548697/193059981-867bd58e-2e7f-4ce0-9f19-1282bfe10e95.png)
